### PR TITLE
 Refactor: remove nnnecessary `global` statements

### DIFF
--- a/eg/ch05/Traffic_Lights.py
+++ b/eg/ch05/Traffic_Lights.py
@@ -8,8 +8,8 @@ led_green = machine.Pin(13, machine.Pin.OUT)
 button = machine.Pin(16, machine.Pin.IN, machine.Pin.PULL_DOWN)
 buzzer = machine.Pin(12, machine.Pin.OUT)
 
-global button_pressed
-button_pressed = False
+# global button_pressed
+button_pressed = False  # No need for global
 
 def button_reader_thread():
     global button_pressed 
@@ -28,7 +28,8 @@ while True:
             time.sleep(0.04) 
             buzzer.value(0)
             time.sleep(0.2)
-        global button_pressed
+        # global button_pressed  # No need for global, main thread, 
+        # same scope where the button_pressed variable was defined
         button_pressed = False
     led_red.value(1)
     time.sleep(5)

--- a/eg/ch06/Reaction_Game.py
+++ b/eg/ch06/Reaction_Game.py
@@ -16,3 +16,5 @@ led.value(1)
 time.sleep(random.uniform(5, 10))
 led.value(0)
 button.irq(trigger=machine.Pin.IRQ_RISING, handler=btn_handler)
+
+time.sleep(1)  # Gives some time before the program ends


### PR DESCRIPTION
This pull request removes unnecessary `global` statements from Traffic_Lights.py, and adds a pause at the end of reaction_game.py. The changes are as follows:

- Traffic_Lights: removed `global` statements where variables were being assigned in the main thread's scope, as they were already global. These changes improve code readability and maintainability by adhering to best practices for using global variables in Python.
- reaction_game.py: the current code successfully controls the LED and button interrupt functionality. However, the program terminates too quickly after the initial LED flash, even if the button hasn't been pressed. This prevents the button interrupt from working reliably. Addition of `time.sleep(1)` is sufficient, though a `while` loop could be a better option.